### PR TITLE
Increase API cpu/memory limits based on testing

### DIFF
--- a/api/openshift/api.dc.yaml
+++ b/api/openshift/api.dc.yaml
@@ -49,11 +49,11 @@ parameters:
   - name: CPU_REQUEST
     value: '100m'
   - name: CPU_LIMIT
-    value: '400m'
+    value: '500m'
   - name: MEMORY_REQUEST
     value: '512Mi'
   - name: MEMORY_LIMIT
-    value: '1Gi'
+    value: '2Gi'
   - name: REPLICAS
     value: '1'
   - name: REPLICA_MAX

--- a/database/.pipeline/lib/db.deploy.js
+++ b/database/.pipeline/lib/db.deploy.js
@@ -33,8 +33,7 @@ module.exports = (settings) => {
         POSTGRESQL_DATABASE: 'restoration-tracker',
         TZ: phases[phase].tz,
         IMAGE_STREAM_NAMESPACE: phases.build.namespace,
-        VOLUME_CAPACITY:
-          `${name}-postgresql${phases[phase].suffix}` === `${name}-postgresql-dev-deploy` ? '20Gi' : '3Gi'
+        VOLUME_CAPACITY: '3Gi'
       }
     })
   );


### PR DESCRIPTION
Noticed that my api pod for another PR was failing to start due to memory issues (that heap error).
Bumped the CPU a bit as I noticed it was getting close to to the 400 it was at before, but it still ran out of memory, so I bumped the memory to 2Gi and then it started no problem.  1.5Gi also worked, but we had it at 2Gi before, so might just be safer.

Extra: reduced the dev database volume size. It was setting it to 20Gi even though only 2Gi was being used.  It used to default to 3Gi, but I think we upped it back on Invasives because of the large spatial layers Jamie was trying to bring in at the time. Unless volume space is a non-issue and we can make them arbitrarily large?