### PR TITLE
Update migration

### DIFF
--- a/database/src/migrations/20220225205950_update_api_project_delete.ts
+++ b/database/src/migrations/20220225205950_update_api_project_delete.ts
@@ -4,8 +4,10 @@ import path from 'path';
 
 const DB_RELEASE = 'release.0.3.1';
 
+const DB_SCHEMA = process.env.DB_SCHEMA;
+
 /**
- * Apply restoration release changes.
+ * Update `api_delete_project` procedure.
  *
  * @export
  * @param {Knex} knex
@@ -15,11 +17,13 @@ export async function up(knex: Knex): Promise<void> {
   const api_delete_project = fs.readFileSync(path.join(__dirname, DB_RELEASE, 'api_delete_project.sql'));
 
   await knex.raw(`
+    set schema '${DB_SCHEMA}';
+    set search_path = ${DB_SCHEMA},public;
+
     ${api_delete_project}
   `);
 }
 
 export async function down(knex: Knex): Promise<void> {
-  await knex.raw(`
-  `);
+  await knex.raw('');
 }


### PR DESCRIPTION
# Overview

## Links to jira tickets

Follow up from: https://github.com/bcgov/restoration-tracker/pull/35

## This PR contains the following changes

Specify the schema/search path to resolve error in Openshift static deployment.

Didn't have an issue in the PR deploy it appears, so not 100% sure why its different in Openshift.

The error from the db setup pod is below (just for those curious):
```
> restoration-tracker-db@0.0.0 setup /opt/app-root/src
> npm-run-all -l -s migrate:latest seed

[migrate:latest]
[migrate:latest] > restoration-tracker-db@0.0.0 migrate:latest /opt/app-root/src
[migrate:latest] > knex migrate:latest --knexfile ./src/knexfile.ts
[migrate:latest]
[migrate:latest] Requiring external module ts-node/register
[migrate:latest] Working directory changed to ~/src
[migrate:latest] Using environment: dev
[migrate:latest] migration file "20220225205950_update_api_project_delete.ts" failed
[migrate:latest] migration failed with error:
[migrate:latest]     -- api_delete_project.sql
[migrate:latest] drop procedure if exists api_delete_project;
[migrate:latest]
[migrate:latest] create or replace procedure api_delete_project(p_project_id project.project_id%type)
[migrate:latest] language plpgsql
[migrate:latest] security definer
[migrate:latest] as
[migrate:latest] $$
[migrate:latest] -- *******************************************************************
[migrate:latest] -- Procedure: api_delete_project
[migrate:latest] -- Purpose: deletes a project and dependencies
[migrate:latest] --
[migrate:latest] -- MODIFICATION HISTORY
[migrate:latest] -- Person           Date        Comments
[migrate:latest] -- ---------------- ----------- --------------------------------------
[migrate:latest] -- charlie.garrettjones@quartech.com
[migrate:latest] --                  2021-04-19  initial release
[migrate:latest] --                  2021-06-21  added delete survey
[migrate:latest] -- Kjartan.Einarsson@quartech.com
[migrate:latest] --                  2022-02-25  added delete species
[migrate:latest] -- *******************************************************************
[migrate:latest] declare
[migrate:latest]
[migrate:latest] begin
[migrate:latest]   delete from treatment where treatment_unit_id in (select treatment_unit_id from treatment_unit where project_id = p_project_id);
[migrate:latest]   delete from treatment_unit_spatial_component where treatment_unit_id in (select treatment_unit_id from treatment_unit where project_id = p_project_id);
[migrate:latest]   delete from treatment_unit where project_id = p_project_id;
[migrate:latest]
[migrate:latest]   delete from permit where project_id = p_project_id;
[migrate:latest]   delete from project_spatial_component where project_id = p_project_id;
[migrate:latest]   delete from stakeholder_partnership where project_id = p_project_id;
[migrate:latest]   delete from project_funding_source where project_id = p_project_id;
[migrate:latest]   delete from project_iucn_action_classification where project_id = p_project_id;
[migrate:latest]   delete from project_attachment where project_id = p_project_id;
[migrate:latest]   delete from project_first_nation where project_id = p_project_id;
[migrate:latest]   delete from project_participation where project_id = p_project_id;
[migrate:latest]   delete from project_contact where project_id = p_project_id;
[migrate:latest]   delete from nrm_region where project_id = p_project_id;
[migrate:latest]   delete from project_caribou_population_unit where project_id = p_project_id;
[migrate:latest]   delete from project_species where project_id = p_project_id;
[migrate:latest]   delete from project where project_id = p_project_id;
[migrate:latest]
[migrate:latest] exception
[migrate:latest]   when others THEN
[migrate:latest]     raise;
[migrate:latest] end;
[migrate:latest] $$;
[migrate:latest]
[migrate:latest]    - relation "project" does not exist
[migrate:latest]     at Parser.parseErrorMessage (/opt/app-root/src/node_modules/pg-protocol/src/parser.ts:357:11)
[migrate:latest]     at Parser.handlePacket (/opt/app-root/src/node_modules/pg-protocol/src/parser.ts:186:21)
[migrate:latest]     at Parser.parse (/opt/app-root/src/node_modules/pg-protocol/src/parser.ts:101:30)
[migrate:latest]     at Socket.<anonymous> (/opt/app-root/src/node_modules/pg-protocol/src/index.ts:7:48)
[migrate:latest]     at Socket.emit (events.js:400:28)
[migrate:latest]     at Socket.emit (domain.js:470:12)
[migrate:latest]     at addChunk (internal/streams/readable.js:290:12)
[migrate:latest]     at readableAddChunk (internal/streams/readable.js:265:9)
[migrate:latest]     at Socket.Readable.push (internal/streams/readable.js:204:10)
[migrate:latest]     at TCP.onStreamRead (internal/stream_base_commons.js:188:23)
[migrate:latest] npm ERR! code ELIFECYCLE
[migrate:latest] npm ERR! errno 1
[migrate:latest] npm ERR! restoration-tracker-db@0.0.0 migrate:latest: `knex migrate:latest --knexfile ./src/knexfile.ts`
[migrate:latest] npm ERR! Exit status 1
[migrate:latest] npm ERR!
[migrate:latest] npm ERR! Failed at the restoration-tracker-db@0.0.0 migrate:latest script.
[migrate:latest] npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
ERROR: "migrate:latest" exited with 1.
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! restoration-tracker-db@0.0.0 setup: `npm-run-all -l -s migrate:latest seed`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the restoration-tracker-db@0.0.0 setup script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
```
