### PR TITLE
BHBC-1665: Populate project draft name with project name

### DIFF
--- a/app/src/components/formik/ScrollToFormikError.tsx
+++ b/app/src/components/formik/ScrollToFormikError.tsx
@@ -5,7 +5,7 @@ import { IGetProjectForViewResponse } from 'interfaces/useProjectApi.interface';
 import React, { useEffect, useState } from 'react';
 
 interface IScrollToFormikErrorProps {
-  onChangeFormikValues?: (values: FormikContextType<IGetProjectForViewResponse>['values']) => void
+  onChangeFormikValues?: (values: FormikContextType<IGetProjectForViewResponse>['values']) => void;
 }
 
 export const ScrollToFormikError: React.FC<IScrollToFormikErrorProps> = (props) => {
@@ -31,9 +31,9 @@ export const ScrollToFormikError: React.FC<IScrollToFormikErrorProps> = (props) 
 
   useEffect(() => {
     if (props.onChangeFormikValues) {
-      props.onChangeFormikValues(formikProps.values)
+      props.onChangeFormikValues(formikProps.values);
     }
-  }, [formikProps.values])
+  }, [formikProps.values, props]);
 
   useEffect(() => {
     const showSnackBar = (message: string) => {

--- a/app/src/components/formik/ScrollToFormikError.tsx
+++ b/app/src/components/formik/ScrollToFormikError.tsx
@@ -1,14 +1,10 @@
 import { Snackbar } from '@material-ui/core';
 import Alert from '@material-ui/lab/Alert';
-import { useFormikContext, FormikContextType } from 'formik';
+import { useFormikContext } from 'formik';
 import { IGetProjectForViewResponse } from 'interfaces/useProjectApi.interface';
 import React, { useEffect, useState } from 'react';
 
-interface IScrollToFormikErrorProps {
-  onChangeFormikValues?: (values: FormikContextType<IGetProjectForViewResponse>['values']) => void;
-}
-
-export const ScrollToFormikError: React.FC<IScrollToFormikErrorProps> = (props) => {
+export const ScrollToFormikError: React.FC = () => {
   const formikProps = useFormikContext<IGetProjectForViewResponse>();
   const { errors } = formikProps;
   const [openSnackbar, setOpenSnackbar] = useState({ open: false, msg: '' });
@@ -28,12 +24,6 @@ export const ScrollToFormikError: React.FC<IScrollToFormikErrorProps> = (props) 
     'location.region',
     'location.geometry'
   ];
-
-  useEffect(() => {
-    if (props.onChangeFormikValues) {
-      props.onChangeFormikValues(formikProps.values);
-    }
-  }, [formikProps.values, props]);
 
   useEffect(() => {
     const showSnackBar = (message: string) => {

--- a/app/src/components/formik/ScrollToFormikError.tsx
+++ b/app/src/components/formik/ScrollToFormikError.tsx
@@ -1,10 +1,14 @@
 import { Snackbar } from '@material-ui/core';
 import Alert from '@material-ui/lab/Alert';
-import { useFormikContext } from 'formik';
+import { useFormikContext, FormikContextType } from 'formik';
 import { IGetProjectForViewResponse } from 'interfaces/useProjectApi.interface';
 import React, { useEffect, useState } from 'react';
 
-export const ScrollToFormikError: React.FC = () => {
+interface IScrollToFormikErrorProps {
+  onChangeFormikValues?: (values: FormikContextType<IGetProjectForViewResponse>['values']) => void
+}
+
+export const ScrollToFormikError: React.FC<IScrollToFormikErrorProps> = (props) => {
   const formikProps = useFormikContext<IGetProjectForViewResponse>();
   const { errors } = formikProps;
   const [openSnackbar, setOpenSnackbar] = useState({ open: false, msg: '' });
@@ -24,6 +28,12 @@ export const ScrollToFormikError: React.FC = () => {
     'location.region',
     'location.geometry'
   ];
+
+  useEffect(() => {
+    if (props.onChangeFormikValues) {
+      props.onChangeFormikValues(formikProps.values)
+    }
+  }, [formikProps.values])
 
   useEffect(() => {
     const showSnackBar = (message: string) => {

--- a/app/src/features/projects/components/ProjectDraftForm.tsx
+++ b/app/src/features/projects/components/ProjectDraftForm.tsx
@@ -12,7 +12,7 @@ export const ProjectDraftFormInitialValues: IProjectDraftForm = {
 };
 
 export const ProjectDraftFormYupSchema = yup.object().shape({
-  draft_name: yup.string().max(50, 'Cannot exceed 50 characters').required('Required')
+  draft_name: yup.string().max(300, 'Cannot exceed 300 characters').required('Required')
 });
 
 /**

--- a/app/src/features/projects/create/CreateProjectPage.tsx
+++ b/app/src/features/projects/create/CreateProjectPage.tsx
@@ -164,6 +164,8 @@ const CreateProjectPage: React.FC = () => {
 
   const [initialProjectFormData, setInitialProjectFormData] = useState<ICreateProjectRequest>(ProjectFormInitialValues);
 
+  const [projectDraftFormInitialName, setProjectDraftFormInitialName] = React.useState<string>(initialProjectFormData.project.project_name)
+
   // Get draft project fields if draft id exists
   useEffect(() => {
     const getDraftProjectFields = async () => {
@@ -337,7 +339,7 @@ const CreateProjectPage: React.FC = () => {
         component={{
           element: <ProjectDraftForm />,
           initialValues: {
-            draft_name: '' // TODO
+            draft_name: projectDraftFormInitialName
           },
           validationSchema: ProjectDraftFormYupSchema
         }}
@@ -374,7 +376,7 @@ const CreateProjectPage: React.FC = () => {
             validateOnChange={false}
             onSubmit={handleProjectCreation}>
             <>
-              <ScrollToFormikError />
+              <ScrollToFormikError onChangeFormikValues={(values) => setProjectDraftFormInitialName(values.project.project_name)}/>
               <Form noValidate>
                 <Box my={5}>
                   <Grid container spacing={3}>

--- a/app/src/features/projects/create/CreateProjectPage.tsx
+++ b/app/src/features/projects/create/CreateProjectPage.tsx
@@ -164,7 +164,9 @@ const CreateProjectPage: React.FC = () => {
 
   const [initialProjectFormData, setInitialProjectFormData] = useState<ICreateProjectRequest>(ProjectFormInitialValues);
 
-  const [projectDraftFormInitialName, setProjectDraftFormInitialName] = React.useState<string>(initialProjectFormData.project.project_name)
+  const [projectDraftFormInitialName, setProjectDraftFormInitialName] = React.useState<string>(
+    initialProjectFormData.project.project_name
+  );
 
   // Get draft project fields if draft id exists
   useEffect(() => {
@@ -376,7 +378,9 @@ const CreateProjectPage: React.FC = () => {
             validateOnChange={false}
             onSubmit={handleProjectCreation}>
             <>
-              <ScrollToFormikError onChangeFormikValues={(values) => setProjectDraftFormInitialName(values.project.project_name)}/>
+              <ScrollToFormikError
+                onChangeFormikValues={(values) => setProjectDraftFormInitialName(values.project.project_name)}
+              />
               <Form noValidate>
                 <Box my={5}>
                   <Grid container spacing={3}>

--- a/app/src/features/projects/create/CreateProjectPage.tsx
+++ b/app/src/features/projects/create/CreateProjectPage.tsx
@@ -22,6 +22,7 @@ import ProjectContactForm, {
   ProjectContactYupSchema
 } from 'features/projects/components/ProjectContactForm';
 import ProjectDraftForm, {
+  ProjectDraftFormInitialValues,
   IProjectDraftForm,
   ProjectDraftFormYupSchema
 } from 'features/projects/components/ProjectDraftForm';
@@ -163,10 +164,6 @@ const CreateProjectPage: React.FC = () => {
   const [draft, setDraft] = useState({ id: 0, date: '' });
 
   const [initialProjectFormData, setInitialProjectFormData] = useState<ICreateProjectRequest>(ProjectFormInitialValues);
-
-  const [projectDraftFormInitialName, setProjectDraftFormInitialName] = React.useState<string>(
-    initialProjectFormData.project.project_name
-  );
 
   // Get draft project fields if draft id exists
   useEffect(() => {
@@ -341,7 +338,9 @@ const CreateProjectPage: React.FC = () => {
         component={{
           element: <ProjectDraftForm />,
           initialValues: {
-            draft_name: projectDraftFormInitialName
+            draft_name: formikRef.current
+              ? formikRef.current.values.project.project_name
+              : ProjectDraftFormInitialValues.draft_name
           },
           validationSchema: ProjectDraftFormYupSchema
         }}
@@ -378,9 +377,7 @@ const CreateProjectPage: React.FC = () => {
             validateOnChange={false}
             onSubmit={handleProjectCreation}>
             <>
-              <ScrollToFormikError
-                onChangeFormikValues={(values) => setProjectDraftFormInitialName(values.project.project_name)}
-              />
+              <ScrollToFormikError />
               <Form noValidate>
                 <Box my={5}>
                   <Grid container spacing={3}>


### PR DESCRIPTION
# Overview

## Links to jira tickets

https://quartech.atlassian.net/browse/BHBC-1665

## This PR contains the following changes

Create/edit project: Save Draft  
 - Default the draft name field to the project title (if the user had entered one).
 - The user should still be able to overwrite it if they would rather name it something else.