### PR TITLE
Fix the pgdata path to some stable

### DIFF
--- a/database/openshift/db.dc.yaml
+++ b/database/openshift/db.dc.yaml
@@ -53,6 +53,11 @@ parameters:
     name: POSTGRESQL_DATABASE
     required: true
     value: 'restoration-tracker'
+  - description: Set this value to override the /pgdata directory name. By default the hostname of the container is used, which does not work well in OpenShift.
+    displayName: PGDATA Path Override
+    name: PGDATA_PATH_OVERRIDE
+    required: true
+    value: 'restoration-tracker'
   - name: TZ
     description: Database timezone
     required: false
@@ -202,6 +207,8 @@ objects:
                   value: '-c maintenance_work_mem=128MB'
                 - name: PGTZ
                   value: '${TZ}'
+                - name: PGDATA_PATH_OVERRIDE
+                  value: '${PGDATA_PATH_OVERRIDE}'
               image: ' '
               imagePullPolicy: IfNotPresent
               livenessProbe:


### PR DESCRIPTION
if you do not set this value in the database deploy, it will create separate database data directories for each deployment/activation effectively loosing your database.

So if you initially deployed and the pod name is A and then you cycle down and up and a new pod is created called B, you will find that the DB image has created 2 different data directories (A and B) and is now pointing to B, so you database is effectively reset.
