### PR TITLE
BHBC-2070-2: Fix treatment_unit migration

### DIFF
--- a/database/src/migrations/20230419151100_treatment_unit_updates.ts
+++ b/database/src/migrations/20230419151100_treatment_unit_updates.ts
@@ -17,12 +17,19 @@ export async function up(knex: Knex): Promise<void> {
 
     set search_path=restoration;
 
-    -- Alter existing column
+    -- Alter existing column, without check constraint
     alter table treatment_unit 
       alter column reconnaissance_conducted type varchar(50),
-      alter column reconnaissance_conducted drop not null,
-      add check (reconnaissance_conducted in ('yes', 'no', 'not applicable'));
+      alter column reconnaissance_conducted drop not null;
     comment on column treatment_unit.reconnaissance_conducted is 'Describes if reconnaissance was conducted for a treatment unit.';
+
+    -- Migrate any existing data in existing column
+    update table treatment_unit set reconnaissance_conducted = 'yes' where reconnaissance_conducted = 'Y';
+    update table treatment_unit set reconnaissance_conducted = 'no' where reconnaissance_conducted = 'N';
+
+    -- Alter existing column, add check constraint
+    alter table treatment_unit 
+      add check (reconnaissance_conducted in ('yes', 'no', 'not applicable'));
 
     -- Add new column
     alter table treatment_unit 


### PR DESCRIPTION
# Overview

## Links to Jira tickets

https://quartech.atlassian.net/browse/BHBC-2070

## Description of relevant changes

- Update migration to correctly account for any existing data, which would no longer fit the new check constraint added to the `reconnaissance_conducted` column.

## PR Checklist

A list of items that are good to consider when making any changes.

_Note: this list is not exhaustive, and not all items are always applicable._

### Code

- [ ] New files/classes/functions have appropriately descriptive names and comment blocks to describe their use/behaviour
- [ ] I have avoided duplicating code when possible, moving re-usable pieces into functions
- [ ] I have avoided hard-coding values where possible and moved any re-usable constants to a constants file
- [ ] My code is as flat as possible (avoids deeply nested if/else blocks, promise chains, etc)
- [ ] My code changes account for null/undefined values and handle errors appropriately
- [ ] My code uses types/interfaces to help describe values/parameters/etc, help ensure type safety, and improve readability

### Style

- [ ] My code follows the established style conventions
- [ ] My code uses native material-ui components/icons/conventions when possible

### Documentation

- [ ] I have commented my code sufficiently, such that an unfamiliar developer could understand my code
- [ ] I have added/updated README's and related documentation, as needed

### Tests

- [ ] I have added/updated unit tests for any code I've added/updated
- [ ] I have added/updated the Postman requests/tests to account for any API endpoints I've added/updated

### Linting/Formatting

- [ ] I have run the linter and fixed any issues, as needed  
       _See the `lint` commands in package.json_
- [ ] I have run the formatter and fixed any issues, as needed  
       _See the `format` commands in package.json_

### SonarCloud

- [ ] I have addressed all SonarCloud Bugs, Vulnerabilities, Security Hotspots, and Code Smells
